### PR TITLE
add missing code quotes around rel link example

### DIFF
--- a/content/post/2019-02-21-hugo-page-bundles/index.Rmd
+++ b/content/post/2019-02-21-hugo-page-bundles/index.Rmd
@@ -188,7 +188,7 @@ Another option is to update your `config.toml` file with permalinks like [Yihui 
 
 The default here from Hugo was `/post/:year-:month-:day-:slug/:slug/`.
 
-A small note: if you want to add relative links from a blog post to another post in your same blog. So `[this](/post/2019-02-19-hugo-archetypes/)` becomes [this](/post/2019-02-19-hugo-archetypes/). 
+A small note: if you want to add relative links from a blog post to another post in your same blog. So `[this](/post/2019-02-19-hugo-archetypes/)` becomes `[this](/post/2019-02-19-hugo-archetypes/)`. 
 
 Now, add images and data files to your `r emo::ji("heart")`'s content! But you may want to do one more thing...
 


### PR DESCRIPTION
Missing the code quote backticks.

The example on the website renders the actual URL link, not the markdown code showing the relative link.

https://alison.rbind.io/post/2019-02-21-hugo-page-bundles/