### PR TITLE
Update params.toml

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -27,7 +27,7 @@ logo = ""
 # Enable global source code highlighting? true/false
 # Documentation: https://sourcethemes.com/academic/docs/writing-markdown-latex/#highlighting-options
 highlight = true
-highlight_languages = ["r", "css", "bash", "js", "markdown", "html"]  # Add support for highlighting additional languages
+highlight_languages = ["r", "css", "bash", "javascript", "markdown"]  # Add support for highlighting additional languages
 highlight_style = "paraiso-light"  # For supported styles, see https://cdnjs.com/libraries/highlight.js/
 
 # Enable global LaTeX math rendering?


### PR DESCRIPTION
These were causing a 404 error as the files did not exist in the cdn.

The js language should actually be javascript, and there doesn't seem to be html in cdnjs repo, <https://cdnjs.com/libraries/highlight.js>, so I removed it.