### PR TITLE
add missing slash for hugo bundles page

### DIFF
--- a/content/post/2019-02-21-hugo-page-bundles/index.Rmd
+++ b/content/post/2019-02-21-hugo-page-bundles/index.Rmd
@@ -82,7 +82,7 @@ readr::write_csv(baker_results, rmarkdown::relative_to(mypostpath, "bakers.csv")
 
 # Bundle Me, blogdown!
 
-First, read the previous post on setting up a [netlify.toml file](post/2019-02-19-hugo-netlify-toml/). Since using Hugo page bundles depends on Hugo v0.32 or higher, you should go ahead and update hugo then update your netlify.toml with your updated version:
+First, read the previous post on setting up a [netlify.toml file](/post/2019-02-19-hugo-netlify-toml/). Since using Hugo page bundles depends on Hugo v0.32 or higher, you should go ahead and update hugo then update your netlify.toml with your updated version:
 
 ```{r eval = FALSE}
 blogdown::update_hugo()

--- a/content/post/2019-02-21-hugo-page-bundles/index.html
+++ b/content/post/2019-02-21-hugo-page-bundles/index.html
@@ -60,7 +60,7 @@ post/2015-07-24-bye-world/index.Rmd</code></pre>
 </div>
 <div id="bundle-me-blogdown" class="section level1">
 <h1>Bundle Me, blogdown!</h1>
-<p>First, read the previous post on setting up a <a href="post/2019-02-19-hugo-netlify-toml/">netlify.toml file</a>. Since using Hugo page bundles depends on Hugo v0.32 or higher, you should go ahead and update hugo then update your netlify.toml with your updated version:</p>
+<p>First, read the previous post on setting up a <a href="/post/2019-02-19-hugo-netlify-toml/">netlify.toml file</a>. Since using Hugo page bundles depends on Hugo v0.32 or higher, you should go ahead and update hugo then update your netlify.toml with your updated version:</p>
 <pre class="r"><code>blogdown::update_hugo()
 blogdown::hugo_version()</code></pre>
 <p>Now, let’s use the <a href="https://usethis.r-lib.org/"><strong>usethis</strong> package</a>.</p>
@@ -132,7 +132,7 @@ options(
 </div>
 <div id="update-metadata" class="section level1">
 <h1>Update Metadata</h1>
-<p>If you are anything like me, you may draft a blog post then come back to it later. For example, I started this post 2 days ago, but want to publish it today, 2019-06-16. The cool thing that was already built-in to blogdown is the “Update Metadata” Addin. With your blog post open (it should be called <code>index.Rmd</code>)<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>, click on Addins and select “Update Metadata”. You should see a window like this:</p>
+<p>If you are anything like me, you may draft a blog post then come back to it later. For example, I started this post 2 days ago, but want to publish it today, 2019-10-03. The cool thing that was already built-in to blogdown is the “Update Metadata” Addin. With your blog post open (it should be called <code>index.Rmd</code>)<a href="#fn1" class="footnote-ref" id="fnref1"><sup>1</sup></a>, click on Addins and select “Update Metadata”. You should see a window like this:</p>
 <p><img src="update-metadata.png" /></p>
 <p>Check the box to rename the file if the date has changed. RStudio will tell you your file has been deleted- which is technically true since the folder was renamed, but don’t panic!</p>
 <p><img src="file-deleted-warning.png" /></p>
@@ -141,6 +141,6 @@ options(
 <div class="footnotes">
 <hr />
 <ol>
-<li id="fn1"><p>If no post is open, you will get an error: <code>Warning message: The current document does not seem to contain YAML metadata</code><a href="#fnref1" class="footnote-back">↩</a></p></li>
+<li id="fn1"><p>If no post is open, you will get an error: <code>Warning message: The current document does not seem to contain YAML metadata</code><a href="#fnref1" class="footnote-back">↩︎</a></p></li>
 </ol>
 </div>


### PR DESCRIPTION
Was reading up on hugo bundles (✨magic✨, btw) on https://alison.rbind.io/post/2019-02-21-hugo-page-bundles/ and noticed that there was a missing slash to this page: https://alison.rbind.io/post/2019-02-19-hugo-netlify-toml/